### PR TITLE
記事アップデート機能の作成

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import { Route} from 'react-router-dom';
 import BlogList from './containers/BlogList';
 import BlogNew from './containers/BlogNew';
+import BlogUpdate from './containers/BlogUpdate';
 import Login from './containers/Login';
 import {ConnectedRouter} from 'connected-react-router';
 
@@ -13,6 +14,7 @@ class App extends Component {
           <Route path="/" component={Login} exact={true} />
           <Route path="/blog" component={BlogList} />
           <Route path="/blog_new" component={BlogNew} />
+          <Route path="/blog_update" component={BlogUpdate} />
       </ConnectedRouter>  
     );
   }

--- a/src/actions/blogActions.js
+++ b/src/actions/blogActions.js
@@ -24,7 +24,7 @@ export function fetchArticle(token){
     }
 }
 
-export function ariticle_create(title, article, user){
+export function article_create(title, article, user){
     return dispatch => {
         dispatch({type: "ARTICLE_POST_START"});
         //localstrage からtokenを取得する
@@ -50,6 +50,46 @@ export function ariticle_create(title, article, user){
         .then((res) => res.json())
         .then((data) => {
             if(data){
+                dispatch(push('/blog'));
+            } else {
+                alert(data.message);
+                dispatch({type: "FETCH_ARTICLE_ERROR", error: data.message})
+            }
+        })
+        .catch((err) => {
+            dispatch({type: "FETCH_ARTICLE_ERROR", errpr: err});
+        })
+    }
+}
+
+export function article_update(id, title, article, user){
+    return dispatch => {
+        dispatch({type: "ARTICLE_POST_START"});
+        //localstrage からtokenを取得する
+        const token = localStorage.token;
+        //現在のユーザー情報idを取得
+        const user_id = user.id
+
+        fetch(`http://localhost:8000/api/blog/${id}/`, {
+    
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `JWT ${token}`
+            },
+            body: JSON.stringify(
+                {
+                    id: id,
+                    title: title,
+                    article: article,
+                    user: user_id,
+                }
+            )
+        })
+        .then((res) => res.json())
+        .then((data) => {
+            if(data){
+                //ここでget処理=>storeを取得し直す
                 dispatch(push('/blog'));
             } else {
                 alert(data.message);

--- a/src/containers/BlogList.js
+++ b/src/containers/BlogList.js
@@ -4,6 +4,7 @@ import {fetchArticle} from '../actions/blogActions';
 import {logout} from '../actions/authActions';
 import { Link } from 'react-router-dom';
 import DeleteModalWindow from './DeleteModalMenu'
+import BlogUpdate from './BlogUpdate'
 
 class BlogList extends Component {
     componentDidMount(){
@@ -31,6 +32,17 @@ class BlogList extends Component {
                                     <p>{article.article}</p>
                                     <p>{article.created_at}</p>
                                     {this.props.user.id === article.user && <DeleteModalWindow article_id={article.id}/>}
+                                    {this.props.user.id === article.user && 
+                                        <Link to={{
+                                            pathname: "/blog_update",
+                                            state: {
+                                                article_id: article.id,
+                                                article_title: article.title,
+                                                article_article: article.article
+                                            }
+                                        }}>
+                                            UPDATE
+                                        </Link>}
                                 </div>
                             )
                         })

--- a/src/containers/BlogUpdate.js
+++ b/src/containers/BlogUpdate.js
@@ -1,0 +1,70 @@
+import React, {Component} from 'react';
+
+import { connect } from 'react-redux';
+
+import {article_update} from '../actions/blogActions'
+
+class BlogUpdate extends Component {
+    constructor(props){
+        debugger
+        super(props);
+        this.state = {
+            id: this.props.location.state.article_id,
+            title: this.props.location.state.article_title,
+            article: this.props.location.state.article_article
+        }
+    }
+    
+    handleTitleInput(e){
+        this.setState({title: e.target.value})
+    }
+
+    handleArticleInput(e){
+        this.setState({article: e.target.value})
+    }
+
+    clickUpdate(){
+        this.props.article_update(this.state.id, this.state.title, this.state.article, this.props.user);
+    }
+
+    render(){
+        return(
+            <div>
+                <h3>記事投稿</h3>
+                
+                <div>
+                    <label>Title</label>
+                    <input 
+                        value = {this.state.title}
+                        onChange= {this.handleTitleInput.bind(this)}
+                        placeholder="Title"
+                    />
+                </div>
+                <div>
+                    <label>Article</label>
+                    <input
+                        value = {this.state.article}
+                        onChange= {this.handleArticleInput.bind(this)}
+                        placeholder="Article"
+                    />
+                </div>
+                <button onClick={this.clickUpdate.bind(this)}>Update Article</button>
+            </div>
+        )
+    }
+}
+
+//storeから取り出し
+const mapStateToProps = (state) => {
+    return{
+        user: state.auth.user
+    }
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        article_update: (id, title, article, user) => dispatch(article_update(id, title, article, user))
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(BlogUpdate)


### PR DESCRIPTION
記事アップデート機能を作成した。
article_updateアクションの作成して 引数として記事id, title, article, user_idを受け取り、PUTメソッドで更新処理を実装した。
更新後は/blogにリダレクトさせる
記事一覧画面のmapしている箇所にlink toを配置。
アップデート画面とリンクさせ、記事情報のpropsを引き渡した。
BlogNewコンポーネントをベースにBlogUpdateコンポーネントを作成した。
Propsとして受け取った値はコンストラクターでthis.props.location.state.~で受け取り、各inputタグへのvalue
に与えた。更新ボタンを押下後はarticle_updateアクションへdispatchさせ、更新に必要な値を引き渡した。
