### PR TITLE
グラフ日付選択ようのカレンダーモーダルの実装

### DIFF
--- a/src/graph_components/GraphCalendar.js
+++ b/src/graph_components/GraphCalendar.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import Calendar from 'react-calendar';
+ 
+class GraphCalendar extends Component {
+  state = {
+    date: this.props.date,
+  }
+ 
+//   onChange = date_of_birth => this.setState({ date_of_birth })
+ 
+  render() {
+    return (
+      <div>
+        <Calendar
+          onChange={this.props.onSelectDate}
+          value={this.state.date}
+        />
+      </div>
+    );
+  }
+}
+export default GraphCalendar;

--- a/src/graph_components/GraphCalendarModal.js
+++ b/src/graph_components/GraphCalendarModal.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import Modal from 'react-modal';
+import GraphCalendar from './GraphCalendar'
+const customStyles = {
+  content : {
+    top                   : '50%',
+    left                  : '50%',
+    right                 : 'auto',
+    bottom                : 'auto',
+    marginRight           : '-50%',
+    transform             : 'translate(-50%, -50%)'
+ }
+};
+
+Modal.setAppElement('#root') 
+class GraphCalendarModal extends Component {
+  constructor() {
+    super();
+    this.state = {
+      modalIsOpen: false
+    };
+    this.openModal = this.openModal.bind(this);
+    this.afterOpenModal = this.afterOpenModal.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+  openModal() {
+    this.setState({modalIsOpen: true});
+  }
+  afterOpenModal() {
+    this.subtitle.style.color = '#f00';
+  }
+  closeModal() {
+    this.setState({modalIsOpen: false});
+  }
+  render() {
+    return (
+      <div>
+        <button onClick={this.openModal}>SELECT DAY</button>
+        <Modal
+          isOpen={this.state.modalIsOpen}
+          onAfterOpen={this.afterOpenModal}
+          onRequestClose={this.closeModal}
+          style={customStyles}
+          contentLabel="Example Modal"
+        >
+          <h2 ref={subtitle => this.subtitle = subtitle}>SELECT DAY</h2>
+          <GraphCalendar onSelectDate={this.props.onSelectDate} date = {this.props.date}/>
+          <div>Opend</div>
+            <button onClick={this.closeModal}>CLOSE</button>
+        </Modal>
+      </div>
+    );
+  }
+}
+export default GraphCalendarModal;

--- a/src/graph_components/Steps_Hour.js
+++ b/src/graph_components/Steps_Hour.js
@@ -3,17 +3,24 @@ import { ComposedChart , CartesianGrid, Legend,Tooltip, Bar, XAxis, YAxis } from
 import {connect} from 'react-redux';
 import {getHourSteps} from '../actions/graphActions';
 import Header from '../containers/Header'
+import GraphCalendarModal from './GraphCalendarModal'
 
 class Steps_Hour extends Component {
     constructor(props){
         super(props);
         this.state = {
             graphtype: 'hour_steps',
-            date: new Date().toLocaleDateString()
+            date: new Date()
         }
     }
     componentDidMount(){
-        const date = this.state.date
+        const date = this.state.date.toLocaleDateString()
+        this.props.getHourSteps(this.props.token, date);
+    }
+    //カレンダーから日にち受け取り,action作動
+    onSelectDate = (date) =>{
+        this.setState({date:date})
+        date = date.toLocaleDateString()
         this.props.getHourSteps(this.props.token, date);
     }
     render() {
@@ -83,6 +90,7 @@ class Steps_Hour extends Component {
                     fill="#ff0000" ////レーダーの中身の色を指定
                 /> */}
             </ComposedChart>
+            <GraphCalendarModal onSelectDate={this.onSelectDate} date = {this.state.date} />
         </div>
       )
     }


### PR DESCRIPTION
グラフの日付選択ようにカレンダーモーダルを作成した。
親コンポーネントから現在の日付を取得し、デフォルトで選択した状態にしておく。カレンダー選択後はonSelectDate関数で選択した日にちを親コ
ンポーネントに引き渡し、コンストラクターに格納する。
検索のために取り出す時は、toLocalDateString()を使い、文字列にしてアクションに引き渡す。