### PR TITLE
signup画面のカレンダー表示のエラー対処

### DIFF
--- a/src/containers/SignUp.js
+++ b/src/containers/SignUp.js
@@ -28,7 +28,7 @@ class Signup extends Component {
     }
 
     selectDateOfBirth = (date_of_birth) => {
-        this.setState({date_of_birth: date_of_birth.toLocaleDateString().replace(/\//g, '-')})
+        this.setState({date_of_birth: date_of_birth})
     }
 
     handleHeightInput(e){
@@ -44,7 +44,7 @@ class Signup extends Component {
     }
 
     clickSignUp(){
-        this.props.signup(this.state.email, this.state.username, this.state.date_of_birth, this.state.height, this.state.weight, this.state.password);
+        this.props.signup(this.state.email, this.state.username, this.state.date_of_birth.toLocaleDateString().replace(/\//g, '-'), this.state.height, this.state.weight, this.state.password);
     }
 
     render(){
@@ -68,7 +68,7 @@ class Signup extends Component {
                 <div>
                     <label>Your Birth Day</label>
                     < BirthDayCalendarModal selectDateOfBirth={this.selectDateOfBirth} date_of_birth = {this.state.date_of_birth}/>
-                    <p>{this.state.date_of_birth&& this.state.date_of_birth}</p>
+                    <p>{this.state.date_of_birth&& this.state.date_of_birth.toLocaleDateString()}</p>
                 </div>
                 <div>
                     <label>Height</label>


### PR DESCRIPTION
Signup画面のカレンダーを連続で選択すると表示されなくなるエラーが発生したいたため対処した。
具体的にはsignupコンポーネントのコンストラクター格納時にsignupアクションに引き渡す形(-を含んだ日にちデータ)となっていたためカレン
ダーコンポーネントで上手く読み込めなかったためエラーが発生していた。
対処法としてはsignupアクションに引き渡す時にreplaceメソッドを動作させ、そこで日付データを変換するようにし、コンストラクターでは通常
のtimestamp形で格納させておくことで対処した。