### PR TITLE
グラフデータの取得に失敗した場合もstoreを更新

### DIFF
--- a/src/actions/graphActions.js
+++ b/src/actions/graphActions.js
@@ -34,12 +34,15 @@ export function getHourSteps(token,date){
 
                 dispatch({type: "FETCH_HOURSTEPS_SUCCESS", hour_steps_data: hour_steps_data, hour_steps_sum_data: sumHour })
             } else {
-                alert(data.message);
-                dispatch({type: "FETCH_GRAPH_ERROR", error: data.message})
+                //hour_steps_data配列の定義
+                let hour_steps_data = [{'hour': ''}];
+                dispatch({type: "FETCH_GRAPH_NODATA", hour_steps_data: hour_steps_data})
             }
         })
         .catch((err) => {
-            dispatch({type: "FETCH_GRAPH_ERROR", error: err});
+            //データがない場合は既存のstoreを上書き
+            let hour_steps_data = [{'hour': ''}];
+            dispatch({type: "FETCH_GRAPH_ERROR", error: err, hour_steps_data: hour_steps_data});
         })
     }
 }

--- a/src/reducers/graphReducers.js
+++ b/src/reducers/graphReducers.js
@@ -21,11 +21,19 @@ const graphReducer = (state = initState, action) => {
                 hour_steps_data: action.hour_steps_data,
                 hour_steps_sum_data: action.hour_steps_sum_data
             };
+        case "FETCH_GRAPH_NODATA":
+            return{
+                ...state,
+                fetching: false,
+                fetched: true,
+                hour_steps_data: action.hour_steps_data,
+            }
         case "FETCH_GRAPH_ERROR":
             return{
                 ...state,
                 fetching: false,
-                error: action.error
+                error: action.error,
+                hour_steps_data: action.hour_steps_data,
             };
         default:
             return state;


### PR DESCRIPTION
データがない日付を選んだ時にstoreが更新されず、元のデータがある日のデータが残ったままになったためデータの取得に失敗した場合でもstoreを
更新させることにした。