### PR TITLE
画像投稿機能の実装

### DIFF
--- a/src/actions/blogActions.js
+++ b/src/actions/blogActions.js
@@ -28,28 +28,32 @@ export function fetchArticle(token){
     }
 }
 
-export function article_create(title, article, user){
+export function article_create(title, article, image, user){
     return dispatch => {
         dispatch({type: "ARTICLE_POST_START"});
         //localstrage からtokenを取得する
         const token = localStorage.token;
         //現在のユーザー情報idを取得
         const user_id = user.id
+        debugger
+        let formData = new FormData()
+        formData.append('title',title);
+        formData.append('article', article);
+        formData.append('image', image);
+        formData.append('user', user_id);
 
         fetch(`${endpoint}blog/`, {
     
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
+                //'Content-Type': 'application/json',
+                //'Accept': 'application/json, text/plain, */*',
+                //'Content-type':'application/json', 
+                //'Content-Type':'multipart/form-data',
+
                 'Authorization': `JWT ${token}`
             },
-            body: JSON.stringify(
-                {
-                    title: title,
-                    article: article,
-                    user: user_id,
-                }
-            )
+            body: formData
         })
         .then((res) => res.json())
         .then((data) => {
@@ -61,7 +65,7 @@ export function article_create(title, article, user){
             }
         })
         .catch((err) => {
-            dispatch({type: "FETCH_ARTICLE_ERROR", errpr: err});
+            dispatch({type: "FETCH_ARTICLE_ERROR", error: err});
         })
     }
 }

--- a/src/containers/BlogNew.js
+++ b/src/containers/BlogNew.js
@@ -5,12 +5,16 @@ import {Form, Button} from 'react-bootstrap';
 import Header from './Header'
 import '../style/article-form.scss'
 
+const createObjectURL = (window.URL || window.webkitURL).createObjectURL || window.createObjectURL;
+
 class BlogNew extends Component {
     constructor(props){
         super(props);
         this.state = {
             title: "",
-            article:""
+            article:"",
+            image_url:null,
+            image:null
         }
     }
     
@@ -22,8 +26,17 @@ class BlogNew extends Component {
         this.setState({article: e.target.value})
     }
 
+    handelChangeFile(e){
+        let image_file = e.target.files;
+        let image = image_file[0];
+        let image_url = image_file.length===0 ? null:createObjectURL(image_file[0]);
+        this.setState({image_url: image_url})
+        this.setState({image: image})
+    }
+
     clickPost(){
-        this.props.article_create(this.state.title, this.state.article, this.props.user);
+        debugger;
+        this.props.article_create(this.state.title, this.state.article, this.state.image, this.props.user);
     }
 
     render(){
@@ -50,6 +63,11 @@ class BlogNew extends Component {
                             placeholder="Article"
                         />
                     </Form.Group>
+                    <Form.Group controlId="exampleForm.ControlInput1">
+                        <Form.Label>Image</Form.Label>
+                        <input type="file" ref="file" onChange={this.handelChangeFile.bind(this)} />
+                        {this.state.image_url && <img src={this.state.image_url} alt="upload_img" />}
+                    </Form.Group>
                     <Button
                         variant="primary"
                         onClick={this.clickPost.bind(this)}
@@ -73,7 +91,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        article_create: (title, article, user) => dispatch(article_create(title, article, user))
+        article_create: (title, article, image, user) => dispatch(article_create(title, article, image, user))
     }
 }
 


### PR DESCRIPTION
画像投稿機能を実装した。
BlogNewコンポーネントでconstructorにimageを追加した。jsx内ではinputタグで画像fileを受け付け、handleChangeFileでinputタグの変更を受け付け、配列で送られてくるファイルの1番目のみをコンストラクターにimage keyとして格納した。またプレビュー機能を実装するためにimage_url keyにはcreateObjectURL関数を実行した後にコンストラクターに格納した。
article_createアクションではbodyの作成を変更した。formDataインスタンスを作成し、appendしてコンポーネントから引き渡した値をappendした。
またfetch時のheaderはj apiの仕様に基づき、wtの認証部分のみにし,content-typeは外した。