### PR TITLE
歩数表示のデータ取得の変更

### DIFF
--- a/src/actions/graphActions.js
+++ b/src/actions/graphActions.js
@@ -36,13 +36,15 @@ export function getHourSteps(token,date){
             } else {
                 //hour_steps_data配列の定義
                 let hour_steps_data = null;
-                dispatch({type: "FETCH_GRAPH_NODATA", hour_steps_data: hour_steps_data})
+                let sumHour = null;
+                dispatch({type: "FETCH_GRAPH_NODATA", hour_steps_data: hour_steps_data, hour_steps_sum_data: sumHour})
             }
         })
         .catch((err) => {
             //データがない場合は既存のstoreを上書き
             let hour_steps_data = null;
-            dispatch({type: "FETCH_GRAPH_ERROR", error: err, hour_steps_data: hour_steps_data});
+            let sumHour = null;
+            dispatch({type: "FETCH_GRAPH_ERROR", error: err, hour_steps_data: hour_steps_data, hour_steps_sum_data: sumHour});
         })
     }
 }

--- a/src/reducers/graphReducers.js
+++ b/src/reducers/graphReducers.js
@@ -19,7 +19,7 @@ const graphReducer = (state = initState, action) => {
                 fetching: false,
                 fetched: true,
                 hour_steps_data: action.hour_steps_data,
-                hour_steps_sum_data: action.hour_steps_sum_data
+                hour_steps_sum_data: action.hour_steps_sum_data,
             };
         case "FETCH_GRAPH_NODATA":
             return{
@@ -27,6 +27,7 @@ const graphReducer = (state = initState, action) => {
                 fetching: false,
                 fetched: true,
                 hour_steps_data: action.hour_steps_data,
+                hour_steps_sum_data: action.hour_steps_sum_data,
             }
         case "FETCH_GRAPH_ERROR":
             return{
@@ -34,6 +35,7 @@ const graphReducer = (state = initState, action) => {
                 fetching: false,
                 error: action.error,
                 hour_steps_data: action.hour_steps_data,
+                hour_steps_sum_data: action.hour_steps_sum_data,
             };
         default:
             return state;


### PR DESCRIPTION
歩数を取得する時にfetchに失敗した時もstoreが上書きされていなかったので失敗したときは歩数にnullを与えた